### PR TITLE
CASMPET-5120: Switch to sysmgmt Prometheus, disable Jaeger

### DIFF
--- a/kubernetes/cray-kiali/Chart.yaml
+++ b/kubernetes/cray-kiali/Chart.yaml
@@ -19,5 +19,5 @@
 apiVersion: v1
 name: cray-kiali
 description: Cray Shasta Kiali deployment
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.25.0

--- a/kubernetes/cray-kiali/values.yaml
+++ b/kubernetes/cray-kiali/values.yaml
@@ -49,3 +49,8 @@ kiali-operator:
           requests:
             cpu: 10m
             memory: 64Mi
+      external_services:
+        prometheus:
+          url: http://cray-sysmgmt-health-promet-prometheus.sysmgmt-health:9090
+        tracing:
+          enabled: false


### PR DESCRIPTION
### Summary and Scope

Kiali was no longer working since the removal of Prometheus from
the Istio deploy (CASMPET-4467). The Prometheus reference is
updated to the one in sysmgmt-health.

Also, I disabled tracing. This was disabled in Istio recently with
CASMPET-5096.

This commit also updates the version number. There's no other
changes in this repository and it's new for CSM 1.2.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-5120

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed this change and then brought up the Kiali GUI. It doesn't show the prometheus connection error message anymore and I clicked around to make sure things looked like they were working.
I noticed that the link to Jaeger is no longer there.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: None
