### PR TITLE
CASMINST-3848: Add kiali image to annotation

### DIFF
--- a/kubernetes/cray-kiali/.gitignore
+++ b/kubernetes/cray-kiali/.gitignore
@@ -1,2 +1,3 @@
 charts
 requirements.lock
+Chart.lock

--- a/kubernetes/cray-kiali/Chart.yaml
+++ b/kubernetes/cray-kiali/Chart.yaml
@@ -23,7 +23,7 @@
 #
 ---
 apiVersion: v2
-version: 0.2.1
+version: 0.2.2
 name: cray-kiali
 description: Cray Shasta Kiali deployment
 keywords:
@@ -41,3 +41,6 @@ maintainers:
 appVersion: 1.28.1
 annotations:
   artifacthub.io/license: MIT
+  artifacthub.io/images: |
+    - name: kiali
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali:v1.28.1

--- a/kubernetes/cray-kiali/values.yaml
+++ b/kubernetes/cray-kiali/values.yaml
@@ -50,7 +50,7 @@ kiali-operator:
         strategy: anonymous
       deployment:
         image_name: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali
-        image_version: v1.28.1
+        image_version: v1.28.1  # If the kiali image changes, update the annotation in Chart.yaml.
         resources:
           limits:
             cpu: "2"


### PR DESCRIPTION
### Summary and Scope

The kiali:v1.28.1 image is used by the deployment created by the
kiali operator that's deployed by this chart, but it's not being
included in the build. This is because the deployment is created
by the operator and not by a deployment created in a template in
the chart so the tool that extracts images used by charts doesn't
find it.

The fix is to add the kiali image to the artifacthub.io/images
annotation. The tool that extracts images used by charts uses this
annotation.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

### Issues and Related PRs

* Resolves CASMINST-3848

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? N   If not, Why? Overkill for this change.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER)  manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Upgraded to this chart on vshasta and made sure kiali was still working.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
