### PR TITLE
CASMPET-5303: Upgrade Kiali to 1.33.1

### DIFF
--- a/kubernetes/cray-kiali/Chart.yaml
+++ b/kubernetes/cray-kiali/Chart.yaml
@@ -23,7 +23,7 @@
 #
 ---
 apiVersion: v2
-version: 0.2.2
+version: 0.3.0
 name: cray-kiali
 description: Cray Shasta Kiali deployment
 keywords:
@@ -34,13 +34,13 @@ sources:
   - https://github.com/Cray-HPE/cray-kiali
 dependencies:
   - name: kiali-operator
-    version: 1.28.0
+    version: 1.33.0
     repository: https://kiali.org/helm-charts
 maintainers:
   - name: bo-quan
-appVersion: 1.28.1
+appVersion: 1.33.1
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: kiali
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali:v1.28.1
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali:v1.33.1

--- a/kubernetes/cray-kiali/values.yaml
+++ b/kubernetes/cray-kiali/values.yaml
@@ -32,7 +32,7 @@ global:
 kiali-operator:
   image:
     repo: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali-operator
-    tag: v1.28.1
+    tag: v1.33.1
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -50,7 +50,7 @@ kiali-operator:
         strategy: anonymous
       deployment:
         image_name: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali
-        image_version: v1.28.1  # If the kiali image changes, update the annotation in Chart.yaml.
+        image_version: v1.33.1  # If the kiali image changes, update the annotation in Chart.yaml.
         resources:
           limits:
             cpu: "2"


### PR DESCRIPTION
## Summary and Scope

Upgrade Kiali to 1.33.1 to work with Istio 1.9.9. Bumped the chart minor version from 0.2.x to 0.3.0.

## Issues and Related PRs

* Resolves [CASMPET-5303]

## Testing

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

Upgraded Kiali from 1.28 to 1.33, and verified that kiali UI still works and shows the new version.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

