### PR TITLE
CASMPET-5796: upgrade to Kiali v1.36.7 for istio 1.10

### DIFF
--- a/kubernetes/cray-kiali/Chart.yaml
+++ b/kubernetes/cray-kiali/Chart.yaml
@@ -23,7 +23,7 @@
 #
 ---
 apiVersion: v2
-version: 0.3.0
+version: 0.4.0
 name: cray-kiali
 description: Cray Shasta Kiali deployment
 keywords:
@@ -34,13 +34,13 @@ sources:
   - https://github.com/Cray-HPE/cray-kiali
 dependencies:
   - name: kiali-operator
-    version: 1.33.0
+    version: 1.36.0
     repository: https://kiali.org/helm-charts
 maintainers:
   - name: bo-quan
-appVersion: 1.33.1
+appVersion: 1.36.7
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: kiali
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali:v1.33.1
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali:v1.36.7

--- a/kubernetes/cray-kiali/values.yaml
+++ b/kubernetes/cray-kiali/values.yaml
@@ -32,7 +32,7 @@ global:
 kiali-operator:
   image:
     repo: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali-operator
-    tag: v1.33.1
+    tag: v1.36.7
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -50,7 +50,7 @@ kiali-operator:
         strategy: anonymous
       deployment:
         image_name: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali
-        image_version: v1.33.1  # If the kiali image changes, update the annotation in Chart.yaml.
+        image_version: v1.36.7  # If the kiali image changes, update the annotation in Chart.yaml.
         resources:
           limits:
             cpu: "2"


### PR DESCRIPTION
## Summary and Scope

Upgrade kiali to v1.36.7 for istio 1.10. Bumped the chart minor version from 0.3.0 to 0.4.0.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5796](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5796)
* Future work required by [CASMPET-5796](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5796)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

After upgrading the kiali version to v1.36.7, verified that I could still access Kiali UI and Grafana UI link from Kiali console without issues.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

