### PR TITLE
CASMPET-6960: Upgrade kiali to v1.75.0 for istio 1.19.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-NAME ?= cray-kaili
+NAME ?= cray-kiali
 CHART_PATH ?= kubernetes
 CHART_VERSION ?= local
 

--- a/kubernetes/.snyk
+++ b/kubernetes/.snyk
@@ -5,11 +5,11 @@ ignore:
   SNYK-CC-K8S-44:
     - '*':
         reason: This is only general advice to grant fewer permissions.
-        expires: 2023-12-01T00:00:00.000Z
+        expires: 2024-12-01T00:00:00.000Z
         created: 2022-01-11T16:32:42.642Z
   SNYK-CC-K8S-47:
     - '*':
         reason: This is only general advice to grant fewer permissions.
-        expires: 2023-12-01T00:00:00.000Z
+        expires: 2024-12-01T00:00:00.000Z
         created: 2022-01-11T16:32:45.654Z
 patch: {}

--- a/kubernetes/cray-kiali/Chart.yaml
+++ b/kubernetes/cray-kiali/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 ---
 apiVersion: v2
-version: 0.5.2
+version: 0.6.0
 name: cray-kiali
 description: Cray Shasta Kiali deployment
 keywords:
@@ -34,13 +34,13 @@ sources:
   - https://github.com/Cray-HPE/cray-kiali
 dependencies:
   - name: kiali-operator
-    version: 1.41.0
+    version: 1.75.0
     repository: https://kiali.org/helm-charts
 maintainers:
   - name: bo-quan
-appVersion: 1.41.0
+appVersion: 1.75.0
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: kiali
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali:v1.41.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali:v1.75.0

--- a/kubernetes/cray-kiali/values.yaml
+++ b/kubernetes/cray-kiali/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ global:
 kiali-operator:
   image:
     repo: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali-operator
-    tag: v1.41.0
+    tag: v1.75.0
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -42,7 +42,7 @@ kiali-operator:
       memory: "200Mi"
     limits:
       cpu: "2000m"
-      memory: "1Gi"
+      memory: "4Gi"
   allowAdHocKialiImage: true
   cr:
     create: true
@@ -52,7 +52,7 @@ kiali-operator:
         strategy: anonymous
       deployment:
         image_name: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali
-        image_version: v1.41.0  # If the kiali image changes, update the annotation in Chart.yaml.
+        image_version: v1.75.0  # If the kiali image changes, update the annotation in Chart.yaml.
         resources:
           limits:
             cpu: "2"


### PR DESCRIPTION
## Summary and Scope

Upgrade kiali to v1.75.0 for istio 1.19.10. Bumped the chart minor version from 0.5.2 to 0.6.0.
Changed resource limits for kiali-operator

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6960](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6960)
* Future work required by [CASMPET-6721](ttps://jira-pro.it.hpe.com:8443/browse/CASMPET-6721)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `starlord`
  * Craystack VM
  * Virtual Shasta

### Test description:

With the v1.75.0 kiali & kiali-operator images, verified that Kiali was running as expected showing the upgraded version string.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

