### PR TITLE
CASMMON-407: Update prometheus URL to victoria-metrics

### DIFF
--- a/kubernetes/cray-kiali/Chart.yaml
+++ b/kubernetes/cray-kiali/Chart.yaml
@@ -23,7 +23,7 @@
 #
 ---
 apiVersion: v2
-version: 0.6.0
+version: 0.6.1
 name: cray-kiali
 description: Cray Shasta Kiali deployment
 keywords:

--- a/kubernetes/cray-kiali/values.yaml
+++ b/kubernetes/cray-kiali/values.yaml
@@ -62,6 +62,6 @@ kiali-operator:
             memory: 64Mi
       external_services:
         prometheus:
-          url: http://cray-sysmgmt-health-kube-p-prometheus.sysmgmt-health:9090
+          url: http://vmselect-vms.sysmgmt-health.svc.cluster.local:8481/select/0/prometheus
         tracing:
           enabled: false


### PR DESCRIPTION
## Summary and Scope
 
Update prometheus URL to victoria-metrics url because from CSM 1.6 prometheus will be replaced with victoria-metrics.
 
The end result is that many of the GUI functions do not work correctly as Kiali cannot connect to Prometheus.
This PR corrects the Prometheus URL used by Kiali.
 
## Issues and Related PRs
 
_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._
 
* Resolves [CASMMON-407](https://jira-pro.it.hpe.com:8443/browse/CASMMON-407)
 
## Testing
 
_List the environments in which these changes were tested._
 
### Tested on:
 
Fanta
 
### Test description:
 
```
Prometheus url is replaced with vmselect in victoria-metrics from CSM-1.6
 
ncn-m001:/mnt/developer/shreni # kubectl get pod -n sysmgmt-health | grep select
vmselect-vms-0                                                   1/1     Running            0          8m53s
vmselect-vms-1                                                   1/1     Running            0          8m53s
 
-------------------------------------------------------------------------------------------------------------------
 
ncn-m001:/mnt/developer/shreni # kubectl -n istio-system get kiali -o yaml | yq4 eval '.. | select(has("prometheus"))'
grafana:
  url: https://grafana.cmn.fanta.hpc.amslabs.hpecorp.net/
prometheus:
  url: http://vmselect-vms.sysmgmt-health.svc.cluster.local:8481/select/0/prometheus
tracing:
  enabled: false
```
 
----------------------------------------------------------------------------------------------------------------------------
 
![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/53111642/e5bd2de4-98bf-4d25-8917-92aaacccf42b)

![image](https://github.com/Cray-HPE/cray-kiali/assets/53111642/24bbb49f-340d-401f-9214-6c50d69db2c3)

![image](https://github.com/Cray-HPE/cray-kiali/assets/53111642/68e0200f-1c23-4022-9a4f-ecf07920cb1c)

![image](https://github.com/Cray-HPE/cray-kiali/assets/53111642/09058b9c-bfda-48a7-b825-d12b3b0c3ac0)



 