### PR TITLE
CASMPET-7376: Update kiali-operator to v2.10.0

### DIFF
--- a/kubernetes/cray-kiali/Chart.yaml
+++ b/kubernetes/cray-kiali/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022-2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 ---
 apiVersion: v2
-version: 0.6.1
+version: 0.7.0
 name: cray-kiali
 description: Cray Shasta Kiali deployment
 keywords:
@@ -34,13 +34,13 @@ sources:
   - https://github.com/Cray-HPE/cray-kiali
 dependencies:
   - name: kiali-operator
-    version: 1.75.0
+    version: 2.10.0
     repository: https://kiali.org/helm-charts
 maintainers:
   - name: bo-quan
-appVersion: 1.75.0
+appVersion: 2.10.0
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: kiali
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali:v1.75.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali:v2.10.0

--- a/kubernetes/cray-kiali/values.yaml
+++ b/kubernetes/cray-kiali/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022-2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ global:
 kiali-operator:
   image:
     repo: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali-operator
-    tag: v1.75.0
+    tag: v2.10.0
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -52,7 +52,7 @@ kiali-operator:
         strategy: anonymous
       deployment:
         image_name: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali
-        image_version: v1.75.0  # If the kiali image changes, update the annotation in Chart.yaml.
+        image_version: v2.10.0  # If the kiali image changes, update the annotation in Chart.yaml.
         resources:
           limits:
             cpu: "2"


### PR DESCRIPTION
## Summary and Scope

Add kiali-operator image v2.10.0 for upgrade in CSM 1.7.

## Issues and Related PRs

* Related to [CASMPET-7376](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7376)
* Image PR: https://github.com/Cray-HPE/container-images/pull/664

## Testing

  * Virtual Shasta
  * gordo

### Test description:

Running the following script:
```
#!/bin/bash

kubectl get pods -n istio-system | grep kiali

kubectl port-forward svc/kiali -n istio-system 20001:20001 &
PORT_FORWARD_PID=$!

sleep 5

# Fetch Kiali metrics
echo "Fetching Kiali metrics..."
curl -s http://localhost:20001/kiali/api/namespaces | head -c 50
echo ''

kill $PORT_FORWARD_PID
```

Resulted in the following output:
```
# ./test-kiali.sh
kiali-6fc596d955-779b6                                 1/1     Running   0          20h
Forwarding from 127.0.0.1:20001 -> 20001
Forwarding from [::1]:20001 -> 20001
Fetching Kiali metrics...
Handling connection for 20001
[{"name":"argo","cluster":"Kubernetes","isAmbient"
```

Tested before and after upgrade:
```
# kubectl describe pod -n operators cray-kiali-kiali-operator-bd69d5879-w6482 | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali-operator:v2.10.0
```

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

